### PR TITLE
解决无法使用APNS开发环境的问题

### DIFF
--- a/push_request.go
+++ b/push_request.go
@@ -74,7 +74,7 @@ type PushOptions struct {
 	SendNo          int    `json:"sendno,int,omitempty"`
 	TimeToLive      int    `json:"time_to_live,int,omitempty"`
 	OverrideMsgId   int64  `json:"override_msg_id,int64,omitempty"`
-	ApnsProduction  bool   `json:"apns_production,omitempty"`
+	ApnsProduction  bool   `json:"apns_production"`
 	ApnsCollapseId  string `json:"apns_collapse_id,omitempty"`
 	BigPushDuration int    `json:"big_push_duration,int,omitempty"`
 }
@@ -105,6 +105,6 @@ func (res *Response) Map() (map[string]interface{}, error) {
 	return result, err
 }
 
-func (res *Response) Bytes() ([]byte) {
+func (res *Response) Bytes() []byte {
 	return res.data
 }


### PR DESCRIPTION
如果把ApnsProduction设为false，则omitempty属性会导致生成的json对象中忽略此字段，而JPush的REST API默认行为是，如果没有此字段，就默认是APNS生产环境。因此，加上omitempty属性会导致无法使用APNS的开发环境。